### PR TITLE
htmlspecialchars für alle Strings die der User sieht

### DIFF
--- a/templates/EXAMPLE/scoutnet-kalender_inline_kalender_EXAMPLE_list.php
+++ b/templates/EXAMPLE/scoutnet-kalender_inline_kalender_EXAMPLE_list.php
@@ -54,8 +54,8 @@ foreach($events as $event) { /* @var $event SN_Model_Event */
 				// Ort mit PLZ
 				if (trim($event->Location)!="") {
 					echo "Ort: ";
-					if (trim($event->ZIP)!="") {echo $event->ZIP . " ";}
-					echo $event->Location;
+					if (trim($event->ZIP)!="") {echo htmlspecialchars($event->ZIP) . " ";}
+					echo htmlspecialchars($event->Location);
 					echo "<br />";
 				}
 
@@ -74,14 +74,14 @@ foreach($events as $event) { /* @var $event SN_Model_Event */
 				// Autor und zuletzt geaendert
 		                if (trim($event->Author->get_full_name())!="") {
 		                     if ($event->Last_Modified_At != 0) {
-						echo "Autor: " . $event->Author->get_full_name() . "(ge&auml;ndert am " . date('d.m.Y', $event->Last_Modified_At) . ")";
+						echo "Autor: " . htmlspecialchars($event->Author->get_full_name()) . "(ge&auml;ndert am " . date('d.m.Y', $event->Last_Modified_At) . ")";
 					} else {
-						echo "Autor: " . $event->Author->get_full_name() . "(ge&auml;ndert am " . date('d.m.Y',$event->Created_At) . ")";
+						echo "Autor: " . htmlspecialchars($event->Author->get_full_name()) . "(ge&auml;ndert am " . date('d.m.Y',$event->Created_At) . ")";
 					}
 				}
 
 				if (trim($event->Author->get_full_name())!="") {
-					echo "Autor: " . $event->Author->get_full_name() . "(ge&auml;ndert am " . date('d.m.Y', $event->Last_Modified_At) . ")";
+					echo "Autor: " . htmlspecialchars($event->Author->get_full_name()) . "(ge&auml;ndert am " . date('d.m.Y', $event->Last_Modified_At) . ")";
 				}
 				?>
 			</small>

--- a/templates/inline_kalender_list.php
+++ b/templates/inline_kalender_list.php
@@ -18,19 +18,19 @@ foreach($events as $event) { /* @var $event SN_Model_Event */
 	<h2><?php echo date('d.m.Y', $event->Start); ?></span>: <?php echo htmlspecialchars($event->Title); ?></h2>
 	
 	<p>
-		<?php echo $event->Description; ?>
+		<?php echo htmlspecialchars($event->Description); ?>
 		<br />
-		eingetragen von: <?php echo $event->Author->get_full_name(); ?>
+		eingetragen von: <?php echo htmlspecialchars($event->Author->get_full_name()); ?>
 		<br />
 		<?php
 		// Zeigt den Link nur an, wenn das Feld gef�llt ist
 		if (trim($event->URL)!="") {
 			// Zeigt den Link_Text (mit Link) nur an, wenn das Feld gef�llt ist
 			if (trim($event->URL_Text)!="") { ?>
-				Link: <a href="<?php echo $event->URL; ?>"><?php echo $event->URL_Text; ?></a>
+				Link: <a href="<?php echo $event->URL; ?>"><?php echo htmlspecialchars($event->URL_Text); ?></a>
 			<?php }
 				else { ?>
-				Link: <a href="<?php echo $event->URL; ?>"><?php echo $event->Title; ?></a>
+				Link: <a href="<?php echo $event->URL; ?>"><?php echo htmlspecialchars($event->Title); ?></a>
 			<?php	}
 		}
 		?>

--- a/templates/widget_kalender_list.php
+++ b/templates/widget_kalender_list.php
@@ -21,7 +21,7 @@ date_default_timezone_set('Europe/Berlin');
 		foreach($events as $event) { /* @var $event SN_Model_Event */
 		?>
 			<div>
-				<strong><?php echo date('d.n.Y', $event->Start); ?> <?php echo gmdate('G:i', $event->Start); ?> <?php echo $event->Location; ?></strong><br />
+				<strong><?php echo date('d.n.Y', $event->Start); ?> <?php echo gmdate('G:i', $event->Start); ?> <?php echo htmlspecialchars($event->Location); ?></strong><br />
 				<?php
 				if (trim($event->URL)=="") {
 					echo htmlspecialchars($event->Title);


### PR DESCRIPTION
Im Changelog der Version 1.3 steht:
`Die (theoretisch) unsichere Ausgabe von HTML aus dem Titel und der Beschreibung von Events ist jetzt escaped`
Das stimmt leider so nicht. Lediglich die Titel wurden escaped. 
Es war also immer noch trivial möglich XSS Attacken auszuführen indem man z.B. in seinen Vornamen in Scoutnet HTML oder Javascript Code eingegeben hat.
Das ist also keine rein theoretische Sicherheitslücke wie im Changelog suggeriert wird.

Falls es jemand testen möchte einfach mal in einem der Textfelder in Scoutnet `<script>alert("XSS")</script>` eingeben und dann den Kalender auf seiner Wordpress Seite aufrufen. Wenn ein Event was dieses Feld anzeigt drin ist, bekommst du jetzt sofort ein Popup angezeigt.
Funktioniert beim Vornamen, Nachnamen, Beschreibung, Ort usw. Alles was halt als Text dargestellt wird.

Dieser PR fügt daher bei allen Feldern die das Plugin anzeigt das htmlspecialchars hinzu.

PS: Das Changelog für Version 1.3 sollte korrigiert werden zu: 
`Die unsichere Ausgabe von HTML aus dem Titel von Events ist jetzt escaped`
